### PR TITLE
IMP: add environment file for local testing

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,7 @@
+name: 4web
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - ruby<2.6
+  - rb-jekyll


### PR DESCRIPTION
 `conda env create -f environment.yml` then `bundle install`, then to serve: `bundle exec jekyll serve --livereload`

ruby pinned to < 2.6 because: [Bundler 2.4 release notes](https://bundler.io/v2.4/whats_new.html#old-ruby-and-rubygems-no-longer-supported)