### PR TITLE
UPDATE: Added Micro:bit link and 'Lab Manuals'

### DIFF
--- a/lab-manual.md
+++ b/lab-manual.md
@@ -1,6 +1,9 @@
 # Lab Manual
 
-We are developing a lab manual that can be used as a stand-alone resource for science and other teachers to integrate scientific computing into their classroom.
-You can find an early draft of the [4CSCC Lab Manual here](https://four-corners-scientific-computing.org/lab-manual/).
+We have developed two lab manuals that can be used as a stand-alone resource for science and other teachers to integrate scientific computing into their classroom.
+### Raspberry Pi
+You can find an early draft of our [4CSCC Lab Manual here](https://four-corners-scientific-computing.org/lab-manual/).
+### BBC micro:bit
+We have also established lessons for using the [BBC Micro:bit found here](https://four-corners-scientific-computing.org/4cscc-lab-manual-microbit-makecode/intro.html#).
 
 ![](/images/4cscc-art-1.jpg "4CSCC art.")

--- a/lab-manual.md
+++ b/lab-manual.md
@@ -1,9 +1,11 @@
 # Lab Manual
 
-We have developed two lab manuals that can be used as a stand-alone resource for science and other teachers to integrate scientific computing into their classroom.
-### Raspberry Pi
-You can find an early draft of our [4CSCC Lab Manual here](https://four-corners-scientific-computing.org/lab-manual/).
-### BBC micro:bit
-We have also established lessons for using the [BBC Micro:bit found here](https://four-corners-scientific-computing.org/4cscc-lab-manual-microbit-makecode/intro.html#).
+At this point, we have developed two lab manuals that can be used as a stand-alone resource for science and other teachers to integrate scientific computing into their classroom.
+
+## BBC micro:bit
+Our most recent version, and the one we recommend, is based on the BBC Micro:bit platform. You can find this content at: https://4cscc-microbit.readthedocs.io/.
+
+## Raspberry Pi
+Our original lab manual was based on the Raspberry Pi 400 platform, and still contains some content that hasn't been developed for our Micro:bit version yet. You can find that content at: https://four-corners-scientific-computing.org/lab-manual/.
 
 ![](/images/4cscc-art-1.jpg "4CSCC art.")


### PR DESCRIPTION
@gregcaporaso 

Hello.

We added a link for the Micro:bit lessons, and pluralized the header to read 'Lab Manuals.'